### PR TITLE
Implement sheeit version command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
 # Binaries for programs and plugins
+bin/
 *.exe
 *.exe~
 *.dll

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,14 @@ Always respect .gitignore
 NEVER amend commits. Always create new commits. No exceptions.
 NEVER rebase. Use merge commits to integrate changes.
 
+Build:
+```
+make build
+```
+
 Before committing, run all checks:
 ```
-uv run ruff check
-uv run ruff format --check
-uv run mypy src/
-uv run python -m unittest discover -s tests
+go fmt ./...
+go vet ./...
+go test ./...
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+VERSION := $(shell grep 'var Version' version/version.go | cut -d'"' -f2)
+
+.PHONY: build clean
+
+build:
+	@mkdir -p bin
+	go build -o bin/sheeit .
+
+clean:
+	rm -rf bin

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var format string
+
+var rootCmd = &cobra.Command{
+	Use:   "sheeit",
+	Short: "A CLI for driving spreadsheets",
+	Long:  "sheeit is a command-line tool for driving spreadsheets from the terminal.",
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&format, "format", "plain", "Output format (plain|json)")
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zomglings/sheeit/version"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		if format == "json" {
+			output := map[string]string{"version": version.Version}
+			enc := json.NewEncoder(os.Stdout)
+			if err := enc.Encode(output); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+		} else {
+			fmt.Printf("sheeit version %s\n", version.Version)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/zomglings/sheeit
+
+go 1.23.5

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/zomglings/sheeit
 
 go 1.23.5
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/zomglings/sheeit/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+// Version is the current version of sheeit.
+// This can be overridden at build time using:
+//
+//	go build -ldflags "-X github.com/zomglings/sheeit/version.Version=1.0.0"
+var Version = "0.0.1"


### PR DESCRIPTION
## Summary

- Add `version` package with `Version` variable (default: 0.0.1)
- Add `cmd` package with cobra root and version commands
- Add `main.go` entry point
- Add `Makefile` for building to `bin/`
- Update `.gitignore` for `bin/`
- Update `CLAUDE.md` with Go build/test instructions

## Usage

```
$ sheeit version
sheeit version 0.0.1

$ sheeit version --format json
{"version":"0.0.1"}
```

## Test plan

- [x] `make build` succeeds
- [x] `sheeit version` outputs version in plain format
- [x] `sheeit version --format json` outputs version in JSON format
- [x] `go fmt`, `go vet`, `go test` pass

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)